### PR TITLE
Fixed Path Problem on reference doc

### DIFF
--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -44,7 +44,7 @@ else
       printf "    Converting from markdown to docx...\n"
       #printf "${pandoc_path} -i \"${markdown_file}\" -o \"${document_dir}/${title}.docx\" -f markdown -t docx --reference-docx=${reference_docx} --smart\n"
       cd $file_path
-      ${pandoc_path} -i README.md -o "${cwd}/${document_dir}/${title}.docx" -f markdown -t docx --reference-docx="${cwd}/${reference_path}" --smart
+      ${pandoc_path} -i README.md -o "${cwd}/${document_dir}/${title}.docx" -f markdown -t docx --reference-docx="${reference_path}" --smart
       cd $cwd
       printf "    Generated ${document_dir}/${title}.docx.\n"
     else


### PR DESCRIPTION
path to configured variable was being changed to current working directory. Path check for reference.docx did not match actual path used when pandoc called

45e60c9674d:sox_compliance raposa$ ~/WorkDocs/Documents/PycharmProjects/pandomine/generate_docs.sh 
Scanning directory for README.md files... DONE
Preparing to process markdown files:
  Validating destination directory: docs/ ... DONE
  Validating reference document: /Users/raposa/WorkDocs/Documents/PycharmProjects/pandomine/reference.docx ... FOUND
Processing files:
  ./README.md: #Overview
    Converting from markdown to docx...
pandoc: /Users/raposa/WorkDocs/Documents/PycharmProjects/AWSProServe_Discovery_com/mediagenix/sox_compliance//Users/raposa/WorkDocs/Documents/PycharmProjects/pandomine/reference.docx: openBinaryFile: does not exist (No such file or directory)
    Generated docs/#Overview.docx.
Complete.
